### PR TITLE
Added ability to install plugin from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This plugin, is the simplest way to get exif data of images at Cordova platform 
 
 ## Getting Started
 
-Import the source
+### Installing
 
-```html
-<script type="text/javascript" src="cordova-exif.js"></script>
-```
+	cordova plugin add https://github.com/domax/cordova-exif.git --save
+
+### Usage
 
 Pass imageURI and get the object with EXIF information
 

--- a/cordova-exif.js
+++ b/cordova-exif.js
@@ -684,3 +684,5 @@ var CordovaExif = (function () {
 	};
 
 })();
+
+module.exports = CordovaExif;

--- a/cordova-exif.js
+++ b/cordova-exif.js
@@ -65,28 +65,19 @@ var CordovaExif = (function () {
 
 	Exif = {
 		find: function(image){
-			var marker,
-				offset = 2,
-				exifOffset;
-
 			// Check if is a valid JPEG
-			if (image.getByteAt(0) !== 0xFF || image.getByteAt(1) !== 0xD8) {
-				return false;
-			}
+			if (image.getByteAt(0) !== 0xFF || image.getByteAt(1) !== 0xD8) return false;
 
+			var offset = 2;
 			while (offset < image.length) {
-				if (image.getByteAt(offset) !== 0xFF) {
-					return false;
-				}
-
-				marker = image.getByteAt(offset+1);
-
-				// Check if is a EXIF marker
-				if(marker === 225) {
-					exifOffset = offset + 4;
-					return Exif.read(image, exifOffset);
-				}
+				if (image.getByteAt(offset) === 0xFF) {
+					// Check if is a EXIF marker
+					if (image.getByteAt(offset + 1) === 0xE1)
+						return Exif.read(image, offset + 4);
+					offset += 2;
+				} else ++offset;
 			}
+			return false;
 		},
 
 		read: function(image, start){

--- a/cordova-exif.js
+++ b/cordova-exif.js
@@ -601,7 +601,7 @@ var CordovaExif = (function () {
 
 	BinaryImage = function(imageBin) {
 		var dataOffset = 0;
-
+		this.length = imageBin.length;
 
 		this.getByteAt = function(imageOffset) {
 			return imageBin.charCodeAt(imageOffset + dataOffset) & 0xFF;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "cordova-plugin-exif",
+	"version": "1.0.0",
+	"description": "The simplest way to get EXIF data of images at Cordova/Phonegap platform",
+	"cordova": {
+		"id": "cordova-plugin-exif",
+		"platforms": [
+			"android",
+			"amazon-fireos",
+			"ubuntu",
+			"ios",
+			"wp7",
+			"wp8",
+			"blackberry10",
+			"windows8",
+			"firefoxos",
+			"windows"
+		]
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/domax/cordova-exif"
+	},
+	"keywords": [
+		"cordova",
+		"camera",
+		"file",
+		"exif",
+		"ecosystem:cordova",
+		"cordova-android",
+		"cordova-amazon-fireos",
+		"cordova-ubuntu",
+		"cordova-ios",
+		"cordova-wp7",
+		"cordova-wp8",
+		"cordova-blackberry10",
+		"cordova-windows8",
+		"cordova-firefoxos",
+		"cordova-windows"
+	],
+	"engines": {
+		"cordovaDependencies": {
+			"3.0.0": {
+				"cordova": ">100"
+			}
+		}
+	}
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        id="cordova-plugin-exif"
+        version="1.0.0">
+
+	<name>CordovaExif</name>
+	<description>The simplest way to get EXIF data of images at Cordova/Phonegap platform</description>
+	<license>MIT</license>
+	<keywords>cordova, camera, file, exif</keywords>
+	<repo>https://github.com/domax/cordova-exif.git</repo>
+
+	<dependency id="cordova-plugin-camera" version="^2.0.0"/>
+	<dependency id="cordova-plugin-file" version="^4.0.0"/>
+
+	<js-module src="cordova-exif.js" name="CordovaExif">
+		<clobbers target="window.CordovaExif"/>
+	</js-module>
+
+</plugin>


### PR DESCRIPTION
In addition to subj, there couple bugs were fixed.

README contains a command in "Installing" section where url is my forked repo - feel free to change it to source one.

One more comment: despite this plugin works as designed (gets EXIF data from photo data), it is useless in iOS, because iOS keeps metadata (especially geolocation) separately from photo - it should be obtained with native code. So, if you need geolocation data, I would recommend to use [cordova-plugin-photos](https://github.com/domax/cordova-plugin-photos) instead.
